### PR TITLE
fix: mistake the old pod as the new pod

### DIFF
--- a/pkg/gpu/client.go
+++ b/pkg/gpu/client.go
@@ -80,10 +80,10 @@ func (d devicePluginClient) Restart(ctx context.Context, nodeName string, timeou
 		return fmt.Errorf("error deleting nvidia device plugin pod: %s", err.Error())
 	}
 	// Wait until the Pods gets recreated
-	return d.WaitUntilRunning(ctx, nodeName, timeout)
+	return d.WaitUntilRunning(ctx, nodeName, podList.Items[0].Name, timeout)
 }
 
-func (d devicePluginClient) WaitUntilRunning(ctx context.Context, nodeName string, timeout time.Duration) error {
+func (d devicePluginClient) WaitUntilRunning(ctx context.Context, nodeName string, oldPodName string, timeout time.Duration) error {
 	logger := log.FromContext(ctx)
 
 	ctx, cancel := context.WithTimeout(ctx, timeout)
@@ -103,6 +103,9 @@ func (d devicePluginClient) WaitUntilRunning(ctx context.Context, nodeName strin
 			return false, nil
 		}
 		pod := podList.Items[0]
+		if pod.Name == oldPodName {
+			return false, nil
+		}
 		if pod.DeletionTimestamp != nil {
 			return false, nil
 		}


### PR DESCRIPTION
Fix a bug in restarting the nvidia-device-plugin.
**How did I find it?**
I read the log of mig-agent and found that restarting the nvidia-device-plugin usually completes in less than a second, which is quite abnormal. Then I added some log in the mig-agent to print the new pod's name and found that when the restarting completes in a flash, the new pod's name is the same as the pod that needs to be deleted.
**How do I fix it?**
By reading the code, I think it's because `checkPodRecreated` in `WaitUntilRunning` in `pkg/gpu/client.go` mistake the previous pod as the new one. It's too fast for it to have a `DeletionTimestamp`. So I add a check to compare the name with the old one.
