### PR TITLE
docs(mkdocs): add index.md and make use of relative paths

### DIFF
--- a/docs/en/docs/index.md
+++ b/docs/en/docs/index.md
@@ -1,0 +1,11 @@
+# Overview
+
+`nos` is the open-source module for running AI workloads on Kubernetes in an optimized way, increasing GPU utilization, cutting down infrastructure costs and improving workloads performance.
+
+Currently, the available features are:
+
+* [Dynamic GPU partitioning](dynamic-gpu-partitioning/overview.md): allow to schedule Pods requesting fractions of GPU. GPU partitioning is performed automatically in real-time based on the Pods pending and running in the cluster, so that Pods can request only the resources that are strictly necessary and GPUs are always fully utilized.
+
+* [Elastic Resource Quota management](elastic-resource-quota/overview.md): increase the number of Pods running on the cluster by allowing namespaces to borrow quotas of reserved resources from other namespaces as long as they are not using them.
+
+![](img/gpu-utilization.png)

--- a/docs/mkdocs.yaml
+++ b/docs/mkdocs.yaml
@@ -26,8 +26,8 @@ markdown_extensions:
 
 theme:
   name: material
-  logo: /assets/nebuly_logo.png
-  favicon: /assets/favicon.png
+  logo: ./assets/nebuly_logo.png
+  favicon: ./assets/favicon.png
   palette:
     - media: '(prefers-color-scheme: light)'
       scheme: default


### PR DESCRIPTION
These changes will resolve:
1. [404 on the Home page](https://nebuly-ai.github.io/nos/) because of not having `index.md`
2. not loading logo and favicon because the paths are not relative